### PR TITLE
Fix type truncation in typegen output

### DIFF
--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -3,8 +3,15 @@ import * as path from 'path'
 import { visitProgram } from './visit/visit'
 import { printToFiles } from './print/print'
 import { AppOptions } from './types'
-import { formatDiagnosticsWithColorAndContext, Program } from 'typescript'
+import { Program } from 'typescript'
 import { version } from '../package.json'
+
+// The undocumented defaultMaximumTruncationLength setting determines at what point printed types are truncated.
+// In kea-typegen output, we NEVER want the types truncated, as that results in a syntax error –
+// "... n more ..." is not valid .d.ts syntax. This is a risk with union types in particular, so we disable truncation.
+// See https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/utilities.ts#L563
+// and https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/checker.ts#L6331-L6334.
+(ts as any).defaultMaximumTruncationLength = Infinity
 
 export function runTypeGen(appOptions: AppOptions) {
     let program: Program


### PR DESCRIPTION
Fixes this issue https://github.com/PostHog/posthog/actions/runs/4853282392/jobs/8649263505?pr=15312:

<img width="985" alt="Screenshot 2023-05-02 at 12 41 48" src="https://user-images.githubusercontent.com/4550621/235645508-4afffb24-5df4-43a4-8895-b5c5d1ac7d41.png">

I've not been able to reproduce the problem in logic samples, but monkeypatching `kea-typegen` in my local `posthog` repo to add this does fix the issue.