### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Automatically generate types for `kea()` calls for [Kea 2.2+](https://keajs.org/
 
 ## Docs
 
-https://keajs.org/docs/guide/typescript/
+https://keajs.org/docs/intro/typescript


### PR DESCRIPTION
Apologies, I realised I made a mistake in my other PR https://github.com/keajs/kea-typegen/pull/42, which this fixes