### PR TITLE
fix(codemod): fix undefined import

### DIFF
--- a/src/write/convertToBuilders.ts
+++ b/src/write/convertToBuilders.ts
@@ -56,7 +56,7 @@ export function convertToBuilders(
             }
             imports[importFrom] ??= []
             for (const specifier of path.value.specifiers) {
-                imports[importFrom].push([specifier.imported.name, specifier.local.name])
+                imports[importFrom].push([specifier.imported?.name, specifier.local.name])
             }
             return false
         },


### PR DESCRIPTION
Let me be honest, I have no idea of the consequences of this change, but it helped me get the kea codemod running...

This is the error I encountered before:
```
❯ npx kea-typegen write --convert-to-builders                                                       


🦜 Kea-TypeGen v3.3.0
🥚 TypeScript Config: /Users/thomas/Posthog/posthog/tsconfig.json
DeprecationWarning: 'createParameterDeclaration' has been deprecated since v4.8.0. Decorators have been combined with modifiers. Callers should switch to an overload that does not accept a 'decorators' parameter.
/Users/thomas/Posthog/posthog/node_modules/.pnpm/yargs@16.2.0/node_modules/yargs/build/index.cjs:2772
                throw err;
                ^

TypeError: Cannot read properties of undefined (reading 'name')
    at Context.visitImportDeclaration (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/write/convertToBuilders.js:51:62)
    at Context.invokeVisitorMethod (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:283:51)
    at PVp.visitWithoutReset (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:158:32)
    at NodePath.each (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path.js:88:26)
    at visitChildren (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:179:18)
    at PVp.visitWithoutReset (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:167:20)
    at visitChildren (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:204:25)
    at PVp.visitWithoutReset (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:167:20)
    at visitChildren (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:204:25)
    at PVp.visitWithoutReset (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:167:20)
    at PVp.visit (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:105:29)
    at visit (/Users/thomas/Posthog/posthog/node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/lib/path-visitor.js:81:55)
    at convertToBuilders (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/write/convertToBuilders.js:42:24)
    at /Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/print/print.js:192:59
    at Array.forEach (<anonymous>)
    at printToFiles (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/print/print.js:66:35)
    at goThroughAllTheFiles (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/typegen.js:85:51)
    at runTypeGen (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/typegen.js:95:57)
    at Object.handler (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/cli/typegen.js:14:30)
    at Object.runCommand (/Users/thomas/Posthog/posthog/node_modules/.pnpm/yargs@16.2.0/node_modules/yargs/build/index.cjs:446:48)
    at Object.parseArgs [as _parseArgs] (/Users/thomas/Posthog/posthog/node_modules/.pnpm/yargs@16.2.0/node_modules/yargs/build/index.cjs:2697:57)
    at Object.get [as argv] (/Users/thomas/Posthog/posthog/node_modules/.pnpm/yargs@16.2.0/node_modules/yargs/build/index.cjs:2651:25)
    at Object.<anonymous> (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-typegen@3.3.0_typescript@4.9.5/node_modules/kea-typegen/dist/src/cli/typegen.js:52:14)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.15.0
```