### PR TITLE
patch(typegen): stops `defaultMaximumTruncationLength` getter error

### DIFF
--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -11,7 +11,7 @@ import { version } from '../package.json'
 // "... n more ..." is not valid .d.ts syntax. This is a risk with union types in particular, so we disable truncation.
 // See https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/utilities.ts#L563
 // and https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/checker.ts#L6331-L6334.
-if (!/^5\.\d$/.test(ts.versionMajorMinor)) {
+if (parseInt(ts.versionMajorMinor.split('.')[0]) < 5)) {
     (ts as any).defaultMaximumTruncationLength = Infinity
 }
 

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -6,12 +6,14 @@ import { AppOptions } from './types'
 import { Program } from 'typescript'
 import { version } from '../package.json'
 
-// The undocumented defaultMaximumTruncationLength setting determines at what point printed types are truncated.
+// The undocumented defaultMaximumTruncationLength setting determines at what point printed types are truncated in versions less than 5.
 // In kea-typegen output, we NEVER want the types truncated, as that results in a syntax error –
 // "... n more ..." is not valid .d.ts syntax. This is a risk with union types in particular, so we disable truncation.
 // See https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/utilities.ts#L563
 // and https://github.com/microsoft/TypeScript/blob/cbb8df/src/compiler/checker.ts#L6331-L6334.
-(ts as any).defaultMaximumTruncationLength = Infinity
+if (!/^5\.\d$/.test(ts.versionMajorMinor)) {
+    (ts as any).defaultMaximumTruncationLength = Infinity
+}
 
 export function runTypeGen(appOptions: AppOptions) {
     let program: Program
@@ -27,6 +29,7 @@ export function runTypeGen(appOptions: AppOptions) {
                 target: ts.ScriptTarget.ES5,
                 module: ts.ModuleKind.CommonJS,
                 noEmit: true,
+                noErrorTruncation: true,
             })
         }
         resetProgram()


### PR DESCRIPTION
This PR prevents the error mentioned in #44 from occurring for TypeScript versions >= 5.  I don't know that it's actually solving the underlying problem that modifying `defaultMaximumTruncationLength` was attempting to solve in the latest versions. According to [this long-standing issue](https://github.com/microsoft/TypeScript/issues/26238), it sounds like there hasn't ever been a way to actually modify this value, although that could just be referring to the public configuration options.

I'm more than happy to modify this, but it feels like patching the functionality is likely the most valuable path to move forward quickly rather than trying to identify the "right" way to do this.

Closes #44