### PR TITLE
feat: use local cache to avoid generating logics twice

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+export interface FileCache {
+    [filePath: string]: number
+}
+
+export class KeaTypegenCache {
+    private cache: FileCache = {}
+    private cacheFilePath: string | null = null
+
+    constructor(rootPath: string) {
+        const nodeModulesCacheDir = path.join(rootPath, 'node_modules', '.cache', 'kea-typegen')
+        const nodeModulesCachePath = path.join(nodeModulesCacheDir, 'cache.json')
+
+        try {
+            fs.mkdirSync(nodeModulesCacheDir, { recursive: true })
+            this.cacheFilePath = nodeModulesCachePath
+        } catch (error) {
+            this.cacheFilePath = null;
+        }
+
+        this.loadCache()
+    }
+
+    private loadCache(): void {
+        if (!this.cacheFilePath) {
+            this.cache = {};
+            return;
+        }
+
+        try {
+            const cacheData = fs.readFileSync(this.cacheFilePath, 'utf8')
+            this.cache = JSON.parse(cacheData)
+        } catch (error) {
+            this.cache = {}
+        }
+    }
+
+    public persistCache(): void {
+        if (!this.cacheFilePath) {
+            return;
+        }
+
+        try {
+            fs.writeFileSync(this.cacheFilePath, JSON.stringify(this.cache, null, 2))
+        } catch (error) {
+            console.warn('Failed to save cache file:', error.message)
+        }
+    }
+
+    public isFileChanged(filePath: string): boolean {
+        try {
+            const stats = fs.statSync(filePath)
+            const cachedMtime = this.cache[filePath]
+            return !cachedMtime || cachedMtime < stats.mtimeMs
+        } catch (error) {
+            return true
+        }
+    }
+
+
+    public updateFile(filePath: string): void {
+        try {
+            const stats = fs.statSync(filePath)
+            this.cache[filePath] = stats.mtimeMs
+        } catch (error) {
+            delete this.cache[filePath]
+        }
+    }
+
+    public getChangedFiles(filePaths: string[]): string[] {
+        return filePaths.filter(filePath => this.isFileChanged(filePath))
+    }
+}

--- a/src/cli/typegen.ts
+++ b/src/cli/typegen.ts
@@ -62,6 +62,10 @@ yargs
         describe: 'Show TypeScript errors',
         type: 'boolean',
     })
+    .option('cache', {
+        describe: 'Use cache to skip processing unchanged files',
+        type: 'boolean',
+    })
     .option('verbose', { describe: 'Slightly more verbose output log', type: 'boolean' })
     .demandCommand()
     .help()

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -77,14 +77,14 @@ export function printToFiles(
     const defaultGlobalTypePaths = appOptions.importGlobalTypes
         ? []
         : (program.getCompilerOptions().types || []).map(
-              (type) =>
-                  path.join(
-                      appOptions.packageJsonPath ? path.dirname(appOptions.packageJsonPath) : appOptions.rootPath,
-                      'node_modules',
-                      '@types',
-                      type,
-                  ) + path.sep,
-          )
+            (type) =>
+                path.join(
+                    appOptions.packageJsonPath ? path.dirname(appOptions.packageJsonPath) : appOptions.rootPath,
+                    'node_modules',
+                    '@types',
+                    type,
+                ) + path.sep,
+        )
 
     // Manually ignored
     const ignoredImportPaths = (appOptions.ignoreImportPaths || []).map((importPath) =>
@@ -197,7 +197,7 @@ export function printToFiles(
 
         try {
             existingOutput = fs.readFileSync(typeFileName)?.toString()
-        } catch (error) {}
+        } catch (error) { }
 
         if (
             !existingOutput ||
@@ -234,8 +234,7 @@ export function printToFiles(
                 filesToModify += logicsNeedingImports.length
             } else {
                 log(
-                    `❌ Will not write ${logicsNeedingImports.length} logic type import${
-                        logicsNeedingImports.length === 1 ? '' : 's'
+                    `❌ Will not write ${logicsNeedingImports.length} logic type import${logicsNeedingImports.length === 1 ? '' : 's'
                     }`,
                 )
             }
@@ -250,8 +249,7 @@ export function printToFiles(
                 filesToModify += logicsNeedingPaths.length
             } else {
                 log(
-                    `❌ Will not write ${logicsNeedingPaths.length} logic path${
-                        logicsNeedingPaths.length === 1 ? '' : 's'
+                    `❌ Will not write ${logicsNeedingPaths.length} logic path${logicsNeedingPaths.length === 1 ? '' : 's'
                     }`,
                 )
             }
@@ -268,8 +266,7 @@ export function printToFiles(
                 filesToModify += logicsNeedingConversion.length
             } else {
                 log(
-                    `❌ Will not write ${logicsNeedingConversion.length} logic path${
-                        logicsNeedingConversion.length === 1 ? '' : 's'
+                    `❌ Will not write ${logicsNeedingConversion.length} logic path${logicsNeedingConversion.length === 1 ? '' : 's'
                     }`,
                 )
             }
@@ -278,12 +275,11 @@ export function printToFiles(
 
     if (writtenFiles === 0 && filesToModify === 0) {
         if (appOptions.write) {
-            log(`💚 ${parsedLogics.length} logic type${parsedLogics.length === 1 ? '' : 's'} up to date!`)
+            log(`💚 ${parsedLogics.length} logic type${parsedLogics.length === 1 ? '' : 's'} updated.`)
             log('')
         } else if (filesToWrite > 0 || filesToModify > 0) {
             log(
-                `🚨 Run "kea-typegen write" to save ${filesToWrite + filesToModify} file${
-                    filesToWrite === 1 ? '' : 's'
+                `🚨 Run "kea-typegen write" to save ${filesToWrite + filesToModify} file${filesToWrite === 1 ? '' : 's'
                 } to disk`,
             )
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface NameType {
     typeNode: ts.TypeNode | ts.KeywordTypeNode | ts.ParenthesizedTypeNode
 }
 
-export interface ReducerTransform extends NameType {}
+export interface ReducerTransform extends NameType { }
 
 export interface SelectorTransform extends NameType {
     functionTypes?: { name: string; type: ts.TypeNode }[]
@@ -80,6 +80,8 @@ export interface AppOptions {
     convertToBuilders?: boolean
     /** Show TypeScript errors */
     showTsErrors?: boolean
+    /** Use a cache to avoid processing unchanged files */
+    cache?: boolean
 
     log: (message: string) => void
 }

--- a/src/visit/visit.ts
+++ b/src/visit/visit.ts
@@ -25,7 +25,7 @@ import { visitEvents } from './visitEvents'
 import { visitDefaults } from './visitDefaults'
 import { visitSharedListeners } from './visitSharedListeners'
 import { cloneNode } from 'ts-clone-node'
-import {NodeBuilderFlags} from "typescript";
+import { NodeBuilderFlags } from "typescript";
 
 const visitFunctions = {
     actions: visitActions,
@@ -44,19 +44,21 @@ const visitFunctions = {
     windowValues: visitWindowValues,
 }
 
-export function visitProgram(program: ts.Program, appOptions?: AppOptions): ParsedLogic[] {
+export function visitProgram(program: ts.Program, appOptions?: AppOptions, filesToProcess?: ts.SourceFile[]): ParsedLogic[] {
     const checker = program.getTypeChecker()
     const parsedLogics: ParsedLogic[] = []
     const pluginModules: PluginModule[] = []
     const typeBuilderModules: TypeBuilderModule[] = []
 
-    for (const sourceFile of program.getSourceFiles()) {
+    const sourceFiles = filesToProcess || program.getSourceFiles()
+
+    for (const sourceFile of sourceFiles) {
         if (!sourceFile.isDeclarationFile && !sourceFile.fileName.endsWith('Type.ts')) {
             ts.forEachChild(sourceFile, visitResetContext(checker, pluginModules))
         }
     }
 
-    for (const sourceFile of program.getSourceFiles()) {
+    for (const sourceFile of sourceFiles) {
         if (!sourceFile.isDeclarationFile && !sourceFile.fileName.endsWith('Type.ts')) {
             if (appOptions?.verbose) {
                 appOptions.log(`👀 Visiting: ${path.relative(process.cwd(), sourceFile.fileName)}`)


### PR DESCRIPTION
Adds a `--cache` flag that uses a local cache stored in `node_modules/kea-typegen/cache.json` to avoid generating logics twice if a file is unchanged.

This speeds up running `kea-typegen write` a lot on subsequent calls since we were previously generating all of them. In most cases, only one logic has been changed.

We can also save this cache together with type files we've previously generated between CI runs to speed up type generation.