### PR TITLE
Prettier v3 support and async updates to type generation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,72 @@
+## 3.5.0 - 2025-07-17
+
+- Update to Prettier v3 adding `async` support
+
 ## 3.4.6 - 2025-06-23
+
 - Write the cache into the <root>/.typegen folder
 
 ## 3.4.6 - 2025-06-23
+
 - Create a "--use-cache" option to cache the generated types in ".typegen"
 
 ## 3.4.5 - 2025-06-23
+
 - Reuse old program when running "typegen:write" (small speedup)
 
 ## 3.4.4 - 2025-06-19
+
 - Upgrade to TypeScript 5.4
 
 ## 3.4.3 - 2025-06-19
+
 - Upgrade to TypeScript 5.2
 
 ## 3.4.2 - 2025-06-19
+
 - Upgrade to TypeScript 5.1
 
 ## 3.4.1 - 2025-06-13
+
 - Upgrade to TypeScript 5.0
 
 ## 3.3.7 - 2025-05-22
+
 - Support `lazyLoaders`
 
 ## 3.3.6 - 2025-01-21
+
 - Skip `..` in `path()`
 
 ## 3.3.5 - 2025-01-10
+
 - Resolve duplicate type imports in logic files
 
 ## 3.3.4 - 2023-12-04
+
 - Fix missing logic in connect.
 
 ## 3.3.0 - 2023-08-16
+
 - Sort printed unions and type literals in actions, reducers, etc. This is to keep the output deterministic.
 
 ## 3.2.3 - 2023-08-16
+
 - Fix deprecations and upgrade TypeScript
 
 ## 3.2.2 - 2023-08-16
+
 - Support kea-forms's paths in path cleanup.
 
 ## 3.2.1 - 2023-08-16
+
 - Also support `@types/` imports by removing `@types/`
 
 ## 3.2.0 - 2023-08-16
 
 - Clean up paths in generated import files
-  - Convert `../../node_modules/*` to just `*` 
-  - Convert `../../node_modules/.pnpm/pkg@version/node_modules/*` to just `*` 
+    - Convert `../../node_modules/*` to just `*`
+    - Convert `../../node_modules/.pnpm/pkg@version/node_modules/*` to just `*`
 
 ## 3.1.7 - 2023-08-16
 
@@ -76,8 +95,8 @@
 ## 3.1.0 - 2022-05-24
 
 - Remove support for importing local types by adding to the end of `logicType` in `kea<logicType<Something, Other, Another>>(...)`
-- Instead, `export` all local types, and typegen will import them in `logicType.ts` just like other types, even if they're declared in `logic.ts`. 
-- This will bring a circular import in your code `logic.ts <-> logicType.ts`, but `tsc` seems not to care.   
+- Instead, `export` all local types, and typegen will import them in `logicType.ts` just like other types, even if they're declared in `logic.ts`.
+- This will bring a circular import in your code `logic.ts <-> logicType.ts`, but `tsc` seems not to care.
 
 ## 3.0.0 - 2022-05-12
 
@@ -89,131 +108,131 @@
 
 ## 1.4.3 - 2022-03-18
 
--   Internal: plugins can specify which types they want to import from 'kea'
+- Internal: plugins can specify which types they want to import from 'kea'
 
 ## 1.4.2 - 2021-12-13
 
--   Fix bug introduced with 1.4.1 if your `tsconfig.json` file does not contain a `types` array.
+- Fix bug introduced with 1.4.1 if your `tsconfig.json` file does not contain a `types` array.
 
 ## 1.4.1 - 2021-12-12
 
--   Adds new option, `ignoreImportPaths`, to specify a list of files or folders that typegen will never import from, when adding imports inside `logicType.ts` files.
--   Automatically skips adding imports for global types, as specified via the `types` array in `tsconfig.json`. Each entry in the array (e.g. `node`) will add an import ignore path for `./node_modules/@types/node`. To revert this, set `"importGlobalTypes": true` inside `.kearc` or via the CLI.
+- Adds new option, `ignoreImportPaths`, to specify a list of files or folders that typegen will never import from, when adding imports inside `logicType.ts` files.
+- Automatically skips adding imports for global types, as specified via the `types` array in `tsconfig.json`. Each entry in the array (e.g. `node`) will add an import ignore path for `./node_modules/@types/node`. To revert this, set `"importGlobalTypes": true` inside `.kearc` or via the CLI.
 
 ## 1.4.0 - 2021-12-12
 
--   Support TypeScript 4.5+.
--   Now adds new type imports with `type`, such as: `import type { logicType } from './logicType`.
--   Refactor internals to create nodes newer `ts.factory` methods.
+- Support TypeScript 4.5+.
+- Now adds new type imports with `type`, such as: `import type { logicType } from './logicType`.
+- Refactor internals to create nodes newer `ts.factory` methods.
 
 ## 1.3.0 - 2021-11-08
 
--   Write paths into logics with `--write-paths`. Can be configured in `.kearc` with `writePaths: true`
+- Write paths into logics with `--write-paths`. Can be configured in `.kearc` with `writePaths: true`
 
 ## 1.2.2 - 2021-10-14
 
--   Loaders: Make the `payload` parameter on the `Success` action optional.
+- Loaders: Make the `payload` parameter on the `Success` action optional.
 
 ## 1.2.1 - 2021-10-14
 
--   Improve `kea-loaders` 0.5.0 support
+- Improve `kea-loaders` 0.5.0 support
 
 ## 1.2.0 - 2021-10-14
 
--   Support `kea-loaders` 0.5.0, add `payload` to the success action and `errorObject` to the failure action.
+- Support `kea-loaders` 0.5.0, add `payload` to the success action and `errorObject` to the failure action.
 
 ## 1.1.6 - 2021-10-07
 
--   Support reducers with actions like `[otherLogic().actionTypes.bla]`
+- Support reducers with actions like `[otherLogic().actionTypes.bla]`
 
 ## 1.1.5 - 2021-07-14
 
--   [Fix bug](https://github.com/keajs/kea-typegen/issues/28) with string constant types in action properties when connected with `connect`.
+- [Fix bug](https://github.com/keajs/kea-typegen/issues/28) with string constant types in action properties when connected with `connect`.
 
 ## 1.1.4 - 2021-07-13
 
--   Support declaring `props: {} as SomeInterface`
+- Support declaring `props: {} as SomeInterface`
 
 ## 1.1.3 - 2021-07-13
 
--   Bugfixes
+- Bugfixes
 
 ## 1.1.2 - 2021-07-12
 
--   Export types and `runTypeGen` function
+- Export types and `runTypeGen` function
 
 ## 1.1.1 - 2021-07-12
 
--   Fix main field in package.json
+- Fix main field in package.json
 
 ## 1.1.0 - 2021-07-12
 
--   Experimental support for typegen plugins
+- Experimental support for typegen plugins
 
 ## 1.0.4 - 2021-06-27
 
--   Fix regression
+- Fix regression
 
 ## 1.0.3 - 2021-06-27
 
--   Fix regression
+- Fix regression
 
 ## 1.0.2 - 2021-06-27
 
--   Use explicitly specified function return types if present for actions and selectors (vs detection via compiler api).
--   This helps with namespaced types like `This.That`, as the namespace information is lost in detected types.
+- Use explicitly specified function return types if present for actions and selectors (vs detection via compiler api).
+- This helps with namespaced types like `This.That`, as the namespace information is lost in detected types.
 
 ## 1.0.1 - 2021-06-27
 
--   Republish as 1.0.0 on npm is actually 0.7.2
--   Only import `A` when encountering complex types like `A.B`
+- Republish as 1.0.0 on npm is actually 0.7.2
+- Only import `A` when encountering complex types like `A.B`
 
 ## 1.0.0 - 2021-06-26
 
--   Support auto-importing referenced types into logic types
+- Support auto-importing referenced types into logic types
 
 ## 0.7.2 - 2021-05-30
 
--   Support actions that return payloads with over 16 properties (fix ".. 4 more .." in the generated type).
+- Support actions that return payloads with over 16 properties (fix ".. 4 more .." in the generated type).
 
 ## 0.7.1 - 2021-04-30
 
--   Improve error display, condense logs
+- Improve error display, condense logs
 
 ## 0.7.0 - 2021-04-26
 
--   Fix various bugs from last version.
--   Run with `--no-import` to skip automatically adding imports to logic types.
+- Fix various bugs from last version.
+- Run with `--no-import` to skip automatically adding imports to logic types.
 
 ## 0.6.2 - 2021-04-25
 
--   Automatically add `import { logicType } from './logicType'` statements
--   Automatically add the type to `kea<logicType>()`
--   0.6.0 and 0.6.1 had some bugs, don't use.
+- Automatically add `import { logicType } from './logicType'` statements
+- Automatically add the type to `kea<logicType>()`
+- 0.6.0 and 0.6.1 had some bugs, don't use.
 
 ## 0.5.4 - 2021-03-30
 
--   Support reducers with selectors as defaults
+- Support reducers with selectors as defaults
 
 ## 0.5.3 - 2021-02-23
 
--   Fix type bug with selectors
--   Skip first comment line in generated types when comparing for overwrites
--   Update deps
+- Fix type bug with selectors
+- Skip first comment line in generated types when comparing for overwrites
+- Update deps
 
 ## 0.5.2 - 2021-02-23
 
--   Update and clean up copy
+- Update and clean up copy
 
 ## 0.5.1 - 2021-01-22
 
--   Fix `kea-typegen write` recursive updates
+- Fix `kea-typegen write` recursive updates
 
 ## 0.5.0 - 2021-01-22
 
--   Fix "Record<...>" style shortened types in selectors
--   Add names to selectors
+- Fix "Record<...>" style shortened types in selectors
+- Add names to selectors
 
 ## 0.4.0 - 2020-12-29
 
--   Fixed support for TypeScript 4.1
+- Fixed support for TypeScript 4.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kea-typegen",
-    "version": "3.4.7",
+    "version": "3.5.0",
     "description": "Generate type definitions for kea logic",
     "scripts": {
         "start": "ts-node ./src/cli/typegen.ts",
@@ -28,7 +28,7 @@
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.5",
         "ts-clone-node": "^3.0.0",
-        "prettier": "^2.8.8",
+        "prettier": "^3.6.2",
         "recast": "^0.23.4",
         "yargs": "^16.2.0"
     },

--- a/src/cli/typegen.ts
+++ b/src/cli/typegen.ts
@@ -8,30 +8,15 @@ import { AppOptions } from '../types'
 import { runTypeGen } from '../typegen'
 
 yargs
-    .command(
-        'check',
-        '- check what should be done',
-        (yargs) => {},
-        (argv) => {
-            runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: false, watch: false })
-        },
-    )
-    .command(
-        'write',
-        '- write logicType.ts files',
-        (yargs) => {},
-        (argv) => {
-            runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: true, watch: false })
-        },
-    )
-    .command(
-        'watch',
-        '- watch for changes and write logicType.ts files',
-        (yargs) => {},
-        (argv) => {
-            runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: true, watch: true })
-        },
-    )
+    .command('check', '- check what should be done', {}, async (argv) => {
+        await runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: false, watch: false })
+    })
+    .command('write', '- write logicType.ts files', {}, async (argv) => {
+        await runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: true, watch: false })
+    })
+    .command('watch', '- watch for changes and write logicType.ts files', {}, async (argv) => {
+        await runTypeGen({ ...includeKeaConfig(parsedToAppOptions(argv)), write: true, watch: true })
+    })
     .option('config', { alias: 'c', describe: 'Path to tsconfig.json (otherwise auto-detected)', type: 'string' })
     .option('file', { alias: 'f', describe: "Single file to evaluate (can't be used with --config)", type: 'string' })
     .option('root', {
@@ -69,7 +54,8 @@ yargs
     .option('verbose', { describe: 'Slightly more verbose output log', type: 'boolean' })
     .demandCommand()
     .help()
-    .wrap(80).argv
+    .wrap(80)
+    .parse()
 
 function parsedToAppOptions(parsedOptions) {
     const { root, types, config, file, ...rest } = parsedOptions
@@ -110,13 +96,13 @@ function includeKeaConfig(appOptions: AppOptions): AppOptions {
         const configDirPath = path.dirname(configFilePath)
         try {
             rawData = fs.readFileSync(configFilePath)
-        } catch (e) {
+        } catch {
             console.error(`Error reading Kea config file: ${configFilePath}`)
             process.exit(1)
         }
         try {
             keaConfig = JSON.parse(rawData)
-        } catch (e) {
+        } catch {
             console.error(`Error parsing Kea config JSON: ${configFilePath}`)
             process.exit(1)
         }

--- a/src/write/convertToBuilders.ts
+++ b/src/write/convertToBuilders.ts
@@ -4,7 +4,7 @@ import { print, visit } from 'recast'
 import { runThroughPrettier } from '../print/print'
 import * as fs from 'fs'
 import * as osPath from 'path'
-import { t, b, visitAllKeaCalls, assureImport, getAst } from "./utils";
+import { t, b, visitAllKeaCalls, assureImport, getAst } from './utils'
 
 const supportedProperties = {
     props: 'kea',
@@ -33,7 +33,7 @@ const supportedProperties = {
     events: 'kea',
 }
 
-export function convertToBuilders(
+export async function convertToBuilders(
     appOptions: AppOptions,
     program: ts.Program,
     filename: string,
@@ -120,7 +120,7 @@ export function convertToBuilders(
         }
     }
 
-    const newText = runThroughPrettier(print(ast).code, filename)
+    const newText = await runThroughPrettier(print(ast).code, filename)
     fs.writeFileSync(filename, newText)
 
     log(`🔥 Converted to builders: ${osPath.relative(process.cwd(), filename)}`)

--- a/src/write/writePaths.ts
+++ b/src/write/writePaths.ts
@@ -4,9 +4,14 @@ import { print, visit } from 'recast'
 import { runThroughPrettier } from '../print/print'
 import * as fs from 'fs'
 import * as osPath from 'path'
-import { t, b, visitAllKeaCalls, assureImport, getAst } from "./utils";
+import { t, b, visitAllKeaCalls, assureImport, getAst } from './utils'
 
-export function writePaths(appOptions: AppOptions, program: ts.Program, filename: string, parsedLogics: ParsedLogic[]) {
+export async function writePaths(
+    appOptions: AppOptions,
+    program: ts.Program,
+    filename: string,
+    parsedLogics: ParsedLogic[],
+) {
     const { log } = appOptions
     const sourceFile = program.getSourceFile(filename)
     const rawCode = sourceFile.getText()
@@ -52,7 +57,7 @@ export function writePaths(appOptions: AppOptions, program: ts.Program, filename
     visitAllKeaCalls(ast, parsedLogics, filename, ({ path, parsedLogic }) => {
         const stmt = path.node
         const arg = stmt.arguments[0]
-        const logicPath = parsedLogic.path.filter(p => p !== '..')
+        const logicPath = parsedLogic.path.filter((p) => p !== '..')
 
         if (t.ObjectExpression.check(arg)) {
             const pathProperty = arg.properties.find(
@@ -80,7 +85,7 @@ export function writePaths(appOptions: AppOptions, program: ts.Program, filename
         }
     })
 
-    const newText = runThroughPrettier(print(ast).code, filename)
+    const newText = await runThroughPrettier(print(ast).code, filename)
     fs.writeFileSync(filename, newText)
 
     log(`🔥 Path added: ${osPath.relative(process.cwd(), filename)}`)

--- a/src/write/writeTypeImports.ts
+++ b/src/write/writeTypeImports.ts
@@ -6,7 +6,7 @@ import { runThroughPrettier } from '../print/print'
 import * as fs from 'fs'
 import { t, b, visitAllKeaCalls, getAst } from './utils'
 
-export function writeTypeImports(
+export async function writeTypeImports(
     appOptions: AppOptions,
     program: ts.Program,
     filename: string,
@@ -75,7 +75,7 @@ export function writeTypeImports(
         ])
     })
 
-    const newText = runThroughPrettier(print(ast).code, filename)
+    const newText = await runThroughPrettier(print(ast).code, filename)
     fs.writeFileSync(filename, newText)
 
     log(`🔥 Import added: ${osPath.relative(process.cwd(), filename)}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4530,10 +4530,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
Basically convert a lot of our functions to `async` since Prettier is async-based now. Not much else needed since `yargs` handles `async` functions just fine.